### PR TITLE
Fix the Usernames with NaN elo ladder bug

### DIFF
--- a/server/ladders-local.ts
+++ b/server/ladders-local.ts
@@ -68,6 +68,7 @@ export class LadderStore {
 				const line = dataLine.trim();
 				if (!line) continue;
 				const row = line.split('\t');
+				if (isNaN(Number(row[2]))) continue;
 				ladder.push([toID(row[1]), Number(row[0]), row[1], Number(row[2]), Number(row[3]), Number(row[4]), row[5]]);
 			}
 			// console.log('Ladders(' + this.formatid + ') loaded tsv: ' + JSON.stringify(this.ladder));


### PR DESCRIPTION
Just a quick fix to the ladder bug where Usernames with NaN elo start popping up. Got suggested this by a showdown staff member for a server I work on so thought you would appreciate it since you have 13 of the top spots filled with them on the ou ladder.